### PR TITLE
Fix warning with PHP7.2 which stops IPN working

### DIFF
--- a/src/CommunityStore/Payment/Methods/CommunityStorePaypalStandard/CommunityStorePaypalStandardPaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/CommunityStorePaypalStandard/CommunityStorePaypalStandardPaymentMethod.php
@@ -169,7 +169,7 @@ class CommunityStorePaypalStandardPaymentMethod extends StorePaymentMethod
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_FORBID_REUSE, 1);
-        if(DEBUG == true) {
+        if(defined('DEBUG') && DEBUG == true) {
             curl_setopt($ch, CURLOPT_HEADER, 1);
             curl_setopt($ch, CURLINFO_HEADER_OUT, 1);
         }


### PR DESCRIPTION
This results in incomplete orders with PHP7.2

e.g. from c5 log
Exception Occurred: ...../packages/community_store_paypal_standard/src/CommunityStore/Payment/Methods/CommunityStorePaypalStandard/CommunityStorePaypalStandardPaymentMethod.php:148 Use of undefined constant DEBUG - assumed 'DEBUG' (this will throw an Error in a future version of PHP) (2)